### PR TITLE
Fixing error when using Github pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <link rel="stylesheet" href="./assets/style.css">
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta http-equiv="Permissions-Policy" content="interest-cohort=()">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Prework Study Guide</title>
   </head>


### PR DESCRIPTION
Fixing error related to Github pages (doesn't happen on local). GitHub pages disables FLoC, Google's 3rd party cookie alternative. 